### PR TITLE
Add option to pretty print JSON responses in airnode-rrp-log

### DIFF
--- a/airnode-rrp-log/src/args.rs
+++ b/airnode-rrp-log/src/args.rs
@@ -23,6 +23,9 @@ pub struct Args {
     #[structopt(long, env = "ADDR_CONTRACT")]
     pub address_contract: String,
 
+    /// Pretty print JSON responses
+    #[structopt(long)]
+    pub pretty_print: bool,
     #[structopt(long, env = "BY_PROVIDER_ID")]
     pub by_provider_id: Option<String>,
     #[structopt(long, env = "BY_ENDPOINT_ID")]

--- a/airnode-rrp-log/src/main.rs
+++ b/airnode-rrp-log/src/main.rs
@@ -19,7 +19,7 @@ pub struct State {
 }
 
 impl State {
-    pub fn new(args: Args) -> Self {
+    pub fn new(args: &Args) -> Self {
         Self {
             unknown: BTreeMap::new(),
             filtration: LogFiltration::default(),
@@ -58,7 +58,7 @@ async fn main() -> anyhow::Result<()> {
     let addr_contract =
         H160::from_str(args.address_contract.as_str()).expect("ADDR_CONTRACT is missing");
 
-    let mut state = State::new(args);
+    let mut state = State::new(&args);
     let mut scanner = reader::Scanner::new(
         chain_id,
         args.min_block,

--- a/airnode-rrp-log/src/reader.rs
+++ b/airnode-rrp-log/src/reader.rs
@@ -5,7 +5,7 @@ use web3::types::{FilterBuilder, Log, H160};
 use web3::{Transport, Web3};
 
 pub trait EventHandler {
-    fn on(&mut self, l: Log) -> ();
+    fn on(&mut self, l: Log, pretty_print: bool) -> ();
 }
 
 pub async fn get_transport(source: &str) -> Either<Http, Ipc> {
@@ -79,6 +79,7 @@ impl Scanner {
         web3: &Web3<T>,
         address: H160,
         handler: &mut impl EventHandler,
+        pretty_print: bool,
     ) -> anyhow::Result<u64>
     where
         T: Transport,
@@ -95,7 +96,7 @@ impl Scanner {
             let logs: Vec<Log> = web3.eth().logs(filter).await?;
             if logs.len() > 0 {
                 for l in logs {
-                    handler.on(l.clone());
+                    handler.on(l.clone(), pretty_print);
                 }
             }
             last_block = b.to;

--- a/airnode-rrp-log/src/reader.rs
+++ b/airnode-rrp-log/src/reader.rs
@@ -5,7 +5,7 @@ use web3::types::{FilterBuilder, Log, H160};
 use web3::{Transport, Web3};
 
 pub trait EventHandler {
-    fn on(&mut self, l: Log, pretty_print: bool) -> ();
+    fn on(&mut self, l: Log) -> ();
 }
 
 pub async fn get_transport(source: &str) -> Either<Http, Ipc> {
@@ -79,7 +79,6 @@ impl Scanner {
         web3: &Web3<T>,
         address: H160,
         handler: &mut impl EventHandler,
-        pretty_print: bool,
     ) -> anyhow::Result<u64>
     where
         T: Transport,
@@ -96,7 +95,7 @@ impl Scanner {
             let logs: Vec<Log> = web3.eth().logs(filter).await?;
             if logs.len() > 0 {
                 for l in logs {
-                    handler.on(l.clone(), pretty_print);
+                    handler.on(l.clone());
                 }
             }
             last_block = b.to;


### PR DESCRIPTION
I thought it would be useful to add the ability to pretty print the JSON responses. I've tested it works, but I'm not sure the way I've achieved it is exactly idiomatic rust.